### PR TITLE
Added setAdjustViewBounds for imageView to keep image aspect ratio

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,11 +3,11 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/CropMe.iml" filepath="$PROJECT_DIR$/CropMe.iml" />
-      <module fileurl="file://$PROJECT_DIR$/CropMe.iml" filepath="$PROJECT_DIR$/CropMe.iml" />
+      <module fileurl="file://C:\Users\Wolf\Android\CropMe\CropMe.iml" filepath="C:\Users\Wolf\Android\CropMe\CropMe.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
-      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://C:\Users\Wolf\Android\CropMe\app\app.iml" filepath="C:\Users\Wolf\Android\CropMe\app\app.iml" />
       <module fileurl="file://$PROJECT_DIR$/cropme/cropme.iml" filepath="$PROJECT_DIR$/cropme/cropme.iml" />
-      <module fileurl="file://$PROJECT_DIR$/cropme/cropme.iml" filepath="$PROJECT_DIR$/cropme/cropme.iml" />
+      <module fileurl="file://C:\Users\Wolf\Android\CropMe\cropme\cropme.iml" filepath="C:\Users\Wolf\Android\CropMe\cropme\cropme.iml" />
     </modules>
   </component>
 </project>

--- a/app/src/main/res/layout/activity_crop.xml
+++ b/app/src/main/res/layout/activity_crop.xml
@@ -64,6 +64,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="2"
+            app:cropme_adjust_view_bounds="false"
             app:cropme_background_alpha="80%"
             app:cropme_max_scale="3"
             app:cropme_result_height="80%"

--- a/cropme/src/main/java/com/takusemba/cropme/CropView.java
+++ b/cropme/src/main/java/com/takusemba/cropme/CropView.java
@@ -44,6 +44,7 @@ public class CropView extends FrameLayout implements Croppable {
     private static final float COLOR_DENSITY = 255;
 
     private static final boolean DEFAULT_WITH_BORDER = true;
+    private static final boolean DEFAULT_ADJUST_IMAGE_BOUNDS = true;
 
     private MoveAnimator horizontalAnimator;
     private MoveAnimator verticalAnimator;
@@ -57,6 +58,7 @@ public class CropView extends FrameLayout implements Croppable {
     private RectF restriction;
     private int backgroundAlpha;
     private boolean withBorder;
+    private boolean adjustBounds;
 
     public CropView(@NonNull Context context) {
         this(context, null);
@@ -92,6 +94,8 @@ public class CropView extends FrameLayout implements Croppable {
 
         withBorder = a.getBoolean(R.styleable.CropView_cropme_with_border, DEFAULT_WITH_BORDER);
 
+        adjustBounds = a.getBoolean(R.styleable.CropView_cropme_adjust_view_bounds,DEFAULT_ADJUST_IMAGE_BOUNDS);
+
         a.recycle();
 
         init();
@@ -119,6 +123,7 @@ public class CropView extends FrameLayout implements Croppable {
                 verticalAnimator = new VerticalMoveAnimatorImpl(target, restriction, maxScale);
                 scaleAnimator = new ScaleAnimatorImpl(target, maxScale);
 
+                target.setAdjustViewBounds(adjustBounds);
                 target.setResultRect(restriction);
                 overlayView.setAttrs(restriction, backgroundAlpha, withBorder);
 
@@ -200,6 +205,13 @@ public class CropView extends FrameLayout implements Croppable {
     public void setBitmap(Bitmap bitmap) {
         ImageView image = findViewById(R.id.cropme_image_view);
         image.setImageBitmap(bitmap);
+        image.requestLayout();
+    }
+
+    @Override
+    public void setAdjustViewBounds(Boolean value) {
+        ImageView image = findViewById(R.id.cropme_image_view);
+        image.setAdjustViewBounds(value);
         image.requestLayout();
     }
 

--- a/cropme/src/main/java/com/takusemba/cropme/Croppable.java
+++ b/cropme/src/main/java/com/takusemba/cropme/Croppable.java
@@ -25,4 +25,9 @@ interface Croppable {
      * crop image. fails if image is outside of {@link CropOverlayView#resultRect}
      **/
     void crop(OnCropListener listener);
+
+    /**
+     * set adjustViewBounds to keep image aspect ratio
+     */
+    void setAdjustViewBounds(Boolean value);
 }

--- a/cropme/src/main/res/values/attrs.xml
+++ b/cropme/src/main/res/values/attrs.xml
@@ -6,5 +6,6 @@
         <attr name="cropme_max_scale" format="integer" />
         <attr name="cropme_with_border" format="boolean" />
         <attr name="cropme_background_alpha" format="fraction" />
+        <attr name="cropme_adjust_view_bounds" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Hi TakuSemba,
I have made the following changes to allow a user to keep an images aspect ratio when cropping.

- Added new xml style atribute to allow setAdjustViewBounds to be set on ImageView
- Added public function to allow setAdjustViewBounds to be set on ImageView programmatically
- setAdjustViewBounds are set to "true" as default

Hope you find this helpful.

Kind Regards,
Nico Bos