### PR TITLE
Fix false positive offFrame with full unzoomed picture

### DIFF
--- a/cropme/src/main/java/com/takusemba/cropme/CropLayout.kt
+++ b/cropme/src/main/java/com/takusemba/cropme/CropLayout.kt
@@ -23,6 +23,8 @@ import com.takusemba.cropme.internal.GestureAnimation
 import com.takusemba.cropme.internal.GestureAnimator
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.concurrent.thread
+import kotlin.math.ceil
+import kotlin.math.floor
 
 /**
  * Layout to show Image and Frame.
@@ -162,10 +164,11 @@ class CropLayout @JvmOverloads constructor(
     val targetRect = Rect()
     cropImageView.getHitRect(targetRect)
     return !targetRect.contains(
-        frameRect.left.toInt(),
-        frameRect.top.toInt(),
-        frameRect.right.toInt(),
-        frameRect.bottom.toInt()
+        ceil(frameRect.left.toDouble()).toInt(),
+        ceil(frameRect.top.toDouble()).toInt(),
+        floor(frameRect.right.toDouble()).toInt(),
+        floor(frameRect.bottom.toDouble()).toInt()
+
     )
   }
 


### PR DESCRIPTION
I have the issue #20 , it's because of a float to int on frameRect. 
In my case, `frameRect.left=161.999` when `targetRect.left=162` but `frameRect.left.toInt()=161`. So off frame...
With the good ceil/floor operation, it seems to works in all cases.