### PR TITLE
fix CropImageView zero size

### DIFF
--- a/cropme/src/main/java/com/takusemba/cropme/CropLayout.kt
+++ b/cropme/src/main/java/com/takusemba/cropme/CropLayout.kt
@@ -106,6 +106,10 @@ class CropLayout @JvmOverloads constructor(
 
       override fun onPreDraw(): Boolean {
 
+        if (measuredWidth == 0 && measuredHeight == 0) {
+          return true
+        }
+
         val totalWidth = measuredWidth.toFloat()
         val totalHeight = measuredHeight.toFloat()
         val frameWidth = measuredWidth * percentWidth


### PR DESCRIPTION
Sometimes onPreDraw is called before the view gets its dimensions. As a result, the CropImageView has zero dimensions and ViewTreeObserver.OnPreDrawListener unsubscribes. The fix does not allow you to set the size of the frame of the CropImageView if the view has not yet received the dimensions.